### PR TITLE
Fixed Assertion caused by StringTableAsset being GC'd while being rooted.

### DIFF
--- a/Source/EasyLocalizationToolEditor/Private/ELTEditor.cpp
+++ b/Source/EasyLocalizationToolEditor/Private/ELTEditor.cpp
@@ -858,6 +858,10 @@ bool UELTEditor::GenerateLocFilesImpl(const TArray<FString>& CSVPaths, const FSt
 			{
 				ExistingStringTableAsset->ClearFlags(RF_Public | RF_Standalone);
 #if (ENGINE_MAJOR_VERSION == 5)
+				if (ExistingStringTableAsset->IsRooted())
+				{
+				    ExistingStringTableAsset->RemoveFromRoot();
+				}
 				ExistingStringTableAsset->MarkAsGarbage();
 #else
 				ExistingStringTableAsset->MarkPendingKill();

--- a/Source/EasyLocalizationToolEditor/Private/ELTEditor.cpp
+++ b/Source/EasyLocalizationToolEditor/Private/ELTEditor.cpp
@@ -857,11 +857,11 @@ bool UELTEditor::GenerateLocFilesImpl(const TArray<FString>& CSVPaths, const FSt
 			if (UStringTable* ExistingStringTableAsset = FindObject<UStringTable>(Package, *AssetName))
 			{
 				ExistingStringTableAsset->ClearFlags(RF_Public | RF_Standalone);
-#if (ENGINE_MAJOR_VERSION == 5)
 				if (ExistingStringTableAsset->IsRooted())
 				{
-				    ExistingStringTableAsset->RemoveFromRoot();
+					ExistingStringTableAsset->RemoveFromRoot();
 				}
+#if (ENGINE_MAJOR_VERSION == 5)
 				ExistingStringTableAsset->MarkAsGarbage();
 #else
 				ExistingStringTableAsset->MarkPendingKill();


### PR DESCRIPTION
An existing String Table Asset may be marked rooted by UE5 automatically in certain scenarios, which prevents objects from being GC'd, thus causing an assertion when marking the asset for GC.

I've done a cursory check that it does not occur with MarkPendingKill() for UE <=5.0